### PR TITLE
WIP: Make included static files configurable

### DIFF
--- a/src/wagtail_tag_manager/context_processors.py
+++ b/src/wagtail_tag_manager/context_processors.py
@@ -1,0 +1,8 @@
+from wagtail_tag_manager.settings import StaticFilesSettings
+
+
+def export_static_files_settings(request):
+    return {
+        "WMT_INCLUDE_CSS": StaticFilesSettings.include_css,
+        "WMT_INCLUDE_JS": StaticFilesSettings.include_js,
+    }

--- a/src/wagtail_tag_manager/context_processors.py
+++ b/src/wagtail_tag_manager/context_processors.py
@@ -3,6 +3,6 @@ from wagtail_tag_manager.settings import StaticFilesSettings
 
 def export_static_files_settings(request):
     return {
-        "WMT_INCLUDE_CSS": StaticFilesSettings.include_css,
-        "WMT_INCLUDE_JS": StaticFilesSettings.include_js,
+        "WTM_INCLUDE_CSS": StaticFilesSettings.include_css,
+        "WTM_INCLUDE_JS": StaticFilesSettings.include_js,
     }

--- a/src/wagtail_tag_manager/middleware.py
+++ b/src/wagtail_tag_manager/middleware.py
@@ -6,6 +6,7 @@ from django.templatetags.static import static
 from wagtail_tag_manager.utils import set_cookie
 from wagtail_tag_manager.models import Tag
 from wagtail_tag_manager.strategy import TagStrategy
+from wagtail_tag_manager.settings import StaticFilesSettings
 
 
 class TagManagerMiddleware:
@@ -60,15 +61,17 @@ class TagManagerMiddleware:
                 doc.body["data-wtm-state"] = reverse("wtm:state")
                 doc.body["data-wtm-lazy"] = reverse("wtm:lazy")
 
-                link = doc.new_tag("link")
-                link["rel"] = "stylesheet"
-                link["type"] = "text/css"
-                link["href"] = static("wtm.bundle.css")
-                doc.body.append(link)
+                if StaticFilesSettings.include_css:
+                    link = doc.new_tag("link")
+                    link["rel"] = "stylesheet"
+                    link["type"] = "text/css"
+                    link["href"] = static("wtm.bundle.css")
+                    doc.body.append(link)
 
-                script = doc.new_tag("script")
-                script["type"] = "text/javascript"
-                script["src"] = static("wtm.bundle.js")
-                doc.body.append(script)
+                if StaticFilesSettings.include_js:
+                    script = doc.new_tag("script")
+                    script["type"] = "text/javascript"
+                    script["src"] = static("wtm.bundle.js")
+                    doc.body.append(script)
 
             self.response.content = doc.decode()

--- a/src/wagtail_tag_manager/settings.py
+++ b/src/wagtail_tag_manager/settings.py
@@ -40,3 +40,8 @@ class TagTypeSettings:
 
     def result(self):
         return self.SETTINGS
+
+
+class StaticFilesSettings:
+    include_css = getattr(settings, "WTM_INCLUDE_CSS", True)
+    include_js = getattr(settings, "WTM_INCLUDE_JS", True)


### PR DESCRIPTION
With ``WTM_INCLUDE_CSS`` and ``WTM_INCLUDE_JS`` in your settings.py you can decide, if you want to include the default wtm.bundle.css and wtm.bundle.js. The middleware takes these settings automatically into account.

The contextprocessor makes these values available to templates.

This pull request is not ready to be merged. I want use it as a basis for a discussion about that feature.