### PR TITLE
Add support for Wagtail 2.15 point releases

### DIFF
--- a/sandbox/requirements.txt
+++ b/sandbox/requirements.txt
@@ -1,4 +1,4 @@
 Django>=3.2,<3.3
-wagtail>=2.11,<2.15
+wagtail>=2.11,<2.16
 django-debug-toolbar
 -e .[docs,test]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 
 install_requires = [
-    "wagtail>=2.11,<2.15",
+    "wagtail>=2.11,<2.16",
     "selenium>=3.141.0,<3.142.0",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36,37,38}-django{22,30,31,32}-wagtail{211,212,213,214},lint
+envlist = py{36,37,38}-django{22,30,31,32}-wagtail{211,212,213,214,215},lint
 
 [testenv]
 basepython =
@@ -17,6 +17,7 @@ deps =
     wagtail212: wagtail>=2.12,<2.13
     wagtail213: wagtail>=2.13,<2.14
     wagtail214: wagtail>=2.14,<2.15
+    wagtail215: wagtail>=2.15,<2.16
 
 [testenv:coverage-report]
 basepython = python3.6


### PR DESCRIPTION
`pip install -U wagtail` generates the following warning:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
wagtail-tag-manager 1.1.0 requires wagtail<2.15,>=2.11, but you have wagtail 2.15.2 which is incompatible
```

Wagtail has just released 2.15.2 which [contains a security advisory](https://docs.wagtail.org/en/stable/releases/2.15.2.html), this change adds support for the 2.15.* releases.