### PR TITLE
fix wrong AppConfig detection

### DIFF
--- a/src/wagtail_tag_manager/apps.py
+++ b/src/wagtail_tag_manager/apps.py
@@ -1,0 +1,1 @@
+from .config import WagtailTagManagerConfig


### PR DESCRIPTION
Seems like the code in __init__.py is no longer being recognized in newer versions of Django resulting in extra migrations being needed.

The apps.py file imports the existing class from config.py and prevents this migrations from being needed.

The alternative is to add the app in the INSTALLED_APPS config with the full path to the WagtailTagManagerConfig class